### PR TITLE
Убрал AllowBackup из AndroidManifest 

### DIFF
--- a/threestateswitch/src/main/AndroidManifest.xml
+++ b/threestateswitch/src/main/AndroidManifest.xml
@@ -1,12 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="ir.oveissi.threestateswitch">
 
-          package="ir.oveissi.threestateswitch"
->
-
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-                 android:supportsRtl="true"
-    >
+    <application
+        android:label="@string/app_name"
+        android:supportsRtl="true">
 
     </application>
 


### PR DESCRIPTION
## Описание 
Так надо, чтобы не конфликтовать с клиентскими `AndroidManifest` 